### PR TITLE
alternative pagination navigating to boycotts

### DIFF
--- a/routes/alternative/index.tsx
+++ b/routes/alternative/index.tsx
@@ -316,7 +316,7 @@ export default function Alternative({ data, state }) {
                   pageItem.type === "page"
                     ? (
                       <a
-                        href={`/boycott?page=${pageItem.label}`}
+                        href={`/alternative?page=${pageItem.label}`}
                         class="px-2 py-1 text-sm text-gray-500 rounded-md dark:hover:bg-gray-800 dark:text-gray-300 hover:bg-gray-100"
                       >
                         {pageItem.label}
@@ -333,7 +333,7 @@ export default function Alternative({ data, state }) {
 
           {page !== totalPages && (
             <a
-              href={`/boycott?page=${page + 1}`}
+              href={`/alternative?page=${page + 1}`}
               class="flex items-center px-5 py-2 text-sm text-gray-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800"
             >
               <span>


### PR DESCRIPTION
## Description

Fix: alternative pagination navigating to boycotts pages

### How to test it

click on navigation item in alternatives page

## Approach

change to alternative link.
