### PR TITLE
feat: add number of hidden countries in alternative card

### DIFF
--- a/components/alternativesGrid.tsx
+++ b/components/alternativesGrid.tsx
@@ -37,7 +37,12 @@ export default function AlternativesGrid({ alternatives, state }) {
                             />
                           ))}
                           {alternative.countries.length > 3 && (
-                            <span class="text-gray-400">...</span>
+                            <>
+                              <span class="text-gray-400">...</span>
+                              <div class="w-6 h-6 mx-1 rounded-full bg-green-800">
+                                <span class="text-white text-xs font-bold">+{alternative.countries.length - 3}</span>
+                              </div>
+                            </>
                           )}
           </div>
           <div class="flex my-2">

--- a/routes/boycott/index.tsx
+++ b/routes/boycott/index.tsx
@@ -364,7 +364,12 @@ export default function Boycott({ data, state }) {
                             />
                           ))}
                           {alternative.countries.length > 3 && (
-                            <span class="text-gray-400">...</span>
+                            <>
+                              <span class="text-gray-400">...</span>
+                              <div class="w-6 h-6 mx-1 rounded-full bg-green-800">
+                                <span class="text-white text-xs font-bold">+{alternative.countries.length - 3}</span>
+                              </div>
+                            </>
                           )}
                         </div>
                       </a>


### PR DESCRIPTION
## Description

This PR closes #16 

### How to test it

In the boycott list look for any boycott that has an alternative with more than 3 countries.
You should now see a circle containing the number of hidden countries.

Same thing should be seen in the alternatives page.

### Screenshots
![image](https://github.com/palestirnative/palestirnative/assets/10698248/0d5ee9b6-ccb2-466a-ba58-885d94afabb8)


