### PR TITLE
fix: redirection from category

### DIFF
--- a/utils/create-url.ts
+++ b/utils/create-url.ts
@@ -7,7 +7,10 @@ export function createCategoryURL(categorySlug: string, state: AppState) {
     ...(state.country ? { country: state.country } : {}),
   };
 
-  return `${state.pathname}?${new URLSearchParams(params).toString()}`;
+  const secondSlashIndex = state.pathname?.indexOf('/', 1);
+  const formattedPath = secondSlashIndex !== -1 ? state.pathname?.slice(0, secondSlashIndex) : state.pathname;
+
+  return `${formattedPath}?${new URLSearchParams(params).toString()}`;
 }
 
 export const createCountryURL = (state : AppState, countryCode: string) => {


### PR DESCRIPTION
## Description
when on product page
fix redirection when clicking on category it takes me to the boycott or alternative page based off which category i selected.
instead of displaying the same product page: wrong behaviour.

