### PR TITLE
feat: added show options on focus and added type safety

### DIFF
--- a/islands/form/boycott-form.tsx
+++ b/islands/form/boycott-form.tsx
@@ -1,33 +1,42 @@
-import TagInput from "./tag-input.tsx";
 import { ArrowUpTraySolid } from "https://esm.sh/preact-heroicons";
+import { ObjectId } from "mongodb";
 import { useMemo, useState } from "preact/hooks";
-import Toastify from "toastify";
-import { translate } from "../../utils/translation.ts";
 import { JSX } from "preact/jsx-runtime";
+import Toastify from "toastify";
+import { AppState } from "../../routes/_middleware.ts";
+import { Alternative } from "../../types/alternative.ts";
+import { Category } from "../../types/category.ts";
 import countries from "../../utils/countries.ts";
+import { translate } from "../../utils/translation.ts";
+import type { CountryOption } from "./alternative-form.tsx";
+import TagInput from "./tag-input.tsx";
 
-export type CountryOption = {
-  value: string;
+export type CategoryOption = {
+  value: ObjectId;
   label: string;
+  icon: string;
 };
-export type Option = {
-  value: string;
+export type AlternativeOption = {
+  value: ObjectId;
   label: string;
   logoURL: string;
 };
-
-const categoryTemplate = (category) => (
+const categoryTemplate = (category: CategoryOption) => (
   <span>
     {category.icon} {category.label}
   </span>
 );
 
 export default function BoycottForm(
-  { categories, alternatives, state },
+  { categories, alternatives, state }: {
+    categories: Category[];
+    alternatives: Alternative[];
+    state: AppState;
+  },
 ) {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [logoSource, setLogoSource] = useState(null);
+  const [logoSource, setLogoSource] = useState<string | null>(null);
 
   const submitURL = useMemo(() => {
     return "/boycott";
@@ -40,15 +49,17 @@ export default function BoycottForm(
   const [selectedCountries, setSelectedCountries] = useState<CountryOption[]>(
     [],
   );
-  const [selectedCategories, setSelectedCategories] = useState([]);
-  const [categoryOptions, setCategoryOptions] = useState(
+  const [selectedCategories, setSelectedCategories] = useState<
+    CategoryOption[]
+  >([]);
+  const [categoryOptions, setCategoryOptions] = useState<CategoryOption[]>(
     categories.map((category) => ({
       value: category._id,
       label: category.name,
       icon: category.icon,
     })),
   );
-  const [countryOptions, setCountryOptions] = useState(
+  const [countryOptions, setCountryOptions] = useState<CountryOption[]>(
     countries
       .map((country) => ({
         value: country.code.toLowerCase(),
@@ -57,22 +68,26 @@ export default function BoycottForm(
       .filter((option) => !selectedCountries.includes(option)),
   );
 
-  const handleSelectCategory = (category) => {
+  const handleSelectCategory = (category: CategoryOption) => {
     setSelectedCategories([...selectedCategories, category]);
     setCategoryOptions(
       categoryOptions.filter((option) => option.value !== category.value),
     );
   };
 
-  const handleUnselectCategory = (category) => {
+  const handleUnselectCategory = (category: CategoryOption) => {
     setCategoryOptions([...categoryOptions, category]);
     setSelectedCategories(
       selectedCategories.filter((option) => option.value !== category.value),
     );
   };
 
-  const [selectedAlternatives, setSelectedAlternatives] = useState([]);
-  const [alternativeOptions, setAlternativeOptions] = useState(
+  const [selectedAlternatives, setSelectedAlternatives] = useState<
+    AlternativeOption[]
+  >([]);
+  const [alternativeOptions, setAlternativeOptions] = useState<
+    AlternativeOption[]
+  >(
     alternatives.map((alternative) => ({
       value: alternative._id,
       label: alternative.name,
@@ -80,14 +95,14 @@ export default function BoycottForm(
     })),
   );
 
-  const handleSelectAlternative = (alternative) => {
+  const handleSelectAlternative = (alternative: AlternativeOption) => {
     setSelectedAlternatives([...selectedAlternatives, alternative]);
     setAlternativeOptions(
       alternativeOptions.filter((option) => option.value !== alternative.value),
     );
   };
 
-  const handleUnselectAlternative = (alternative) => {
+  const handleUnselectAlternative = (alternative: AlternativeOption) => {
     setAlternativeOptions([...alternativeOptions, alternative]);
     setSelectedAlternatives(
       selectedAlternatives.filter(
@@ -104,12 +119,12 @@ export default function BoycottForm(
     setSelectedAlternatives([]);
   };
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async (event: Event) => {
     event.preventDefault();
 
     setIsLoading(true);
 
-    const formData = new FormData(event.target);
+    const formData = new FormData(event.target as HTMLFormElement);
 
     const countries = selectedCountries
       .map((country) => country.value)
@@ -160,8 +175,9 @@ export default function BoycottForm(
     });
   };
 
-  const handleLogoChange = (event) => {
-    const logo = event.target.files[0];
+  const handleLogoChange = (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const logo = input?.files ? input.files[0] : null;
 
     if (logo) {
       setLogoSource(URL.createObjectURL(logo));
@@ -193,7 +209,7 @@ export default function BoycottForm(
     </div>
   );
 
-  const optionTemplate = (option: Option): JSX.Element => (
+  const optionTemplate = (option : AlternativeOption): JSX.Element => (
     <div class="flex items-center">
       <img
         src={option.logoURL}
@@ -217,7 +233,7 @@ export default function BoycottForm(
         <div class="my-2 flex flex-col items-center">
           <img
             hidden={!logoSource}
-            src={logoSource}
+            src={logoSource!}
             alt="Logo"
             class="w-32 h-32 my-2 rounded-full object-contain"
           />
@@ -285,7 +301,7 @@ export default function BoycottForm(
             <label class="text-gray-700 dark:text-gray-200" for="categories">
               {state.locale["Countries"]}
             </label>
-            <TagInput<CountryOption>
+            <TagInput
               name="countriesInput"
               tags={selectedCountries}
               handleSelect={handleSelectCountry}


### PR DESCRIPTION
## Description

- Enhanced the `TagInput` component to display options as soon as the input is focused, making the form more user-friendly and intuitive.
- Type safety and state management within the `BoycottForm` component are also improved.

### How to test it

1. Go to the form that uses the `TagInput` component.
2. Click on the input field to focus on it without typing anything.
3. Observe that the options are now displayed immediately upon focus, which was not the case previously.
4. Proceed to interact with the form's categories, alternatives, and countries to ensure functionality remains intact.

### Screenshots

- Screenshots are not provided as the main change is interaction-based and can be directly tested in the form.

---

## Approach

- Modified the `TagInput` component to change the options visibility logic by introducing a new state `isFocused` and corresponding focus/blur event handlers that trigger options display.
- Implemented the use of `useRef` for managing input focus state and added event handlers for focus, blur, and mouse leave interactions.
- Maintained existing functionality while enhancing user interaction with the input field.
- Other improvements included type annotations and state management updates in the `BoycottForm` component.